### PR TITLE
무한스크롤 로딩바 추가

### DIFF
--- a/src/components/loading/InfiniteScrollLoading.tsx
+++ b/src/components/loading/InfiniteScrollLoading.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+
+const InfiniteScrollLoading = () => {
+  return (
+    <Box>
+      <LoadingText>Loading...</LoadingText>
+    </Box>
+  )
+}
+
+const Box = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
+`
+const LoadingText = styled.span`
+  font-size: 24px;
+`
+
+export default InfiniteScrollLoading

--- a/src/components/main/IssueListSection.tsx
+++ b/src/components/main/IssueListSection.tsx
@@ -9,9 +9,11 @@ import useScroll from './hook/useScroll'
 import { sortingIsOpen } from '../../util/sortingIsOpen'
 import { sortingComments } from '../../util/sortingComments'
 import { IssueDataType } from '../../util/type'
+import InfiniteScrollLoading from '../loading/InfiniteScrollLoading'
 
 const IssueListSection = () => {
   const [issueCard, setIssueCard] = useState<IssueDataType[]>([])
+  const [isLoading, setIsLoading] = useState(false)
   const [page, setPage] = useState(1)
   const issueListRef = useRef<HTMLDivElement>(null)
 
@@ -33,6 +35,7 @@ const IssueListSection = () => {
         const sortedData = sortingComments([...issueCard, ...sortedIsOpen])
 
         setIssueCard(sortedData)
+        setIsLoading(false)
       } catch (error) {
         console.log(error)
       }
@@ -43,9 +46,13 @@ const IssueListSection = () => {
 
   useEffect(() => {
     if (scrollHeight !== 0 && refCurrent) {
-      refCurrent.scrollTop >=
-        refCurrent.scrollHeight - refCurrent.clientHeight &&
+      if (
+        refCurrent.scrollTop >=
+        refCurrent.scrollHeight - refCurrent.clientHeight
+      ) {
+        setIsLoading(true)
         setPage((prev) => prev + 1)
+      }
     }
   }, [scrollHeight])
 
@@ -78,6 +85,7 @@ const IssueListSection = () => {
             />
           )
         )}
+        {isLoading && <InfiniteScrollLoading />}
       </Box>
     </Section>
   )


### PR DESCRIPTION
## 분류 #13 

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩토링
- [ ] 디자인
- [ ] 코드포메팅

## 상세내용
- 메인 페이지에서 스크롤이 끝지점 도달시 api 요청을 하게 된다.
  api 요청시 데이터 패칭하는데 시간이 좀 걸리므로
 "데이터가 로딩중이다"라는 걸 표현할 수 있는 로딩컴포넌트를 추가
